### PR TITLE
Add issues:write permission to rebase-upstream workflow

### DIFF
--- a/.github/workflows/rebase-upstream.yml
+++ b/.github/workflows/rebase-upstream.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   rebase:


### PR DESCRIPTION
## Summary
The rebase-upstream.yml workflow attempts to create and close GitHub issues on rebase failure/success, but was missing the required `issues: write` permission. This caused recurring 403 "Resource not accessible by integration" errors.

This fix adds `issues: write` to the workflow permissions, allowing the github-script actions to interact with the repository issues API.

## What changed
- Added `issues: write` to the permissions block in `.github/workflows/rebase-upstream.yml`